### PR TITLE
DD-2234 Support for holey bags

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,8 @@ requirements added by DANS.
 
 Current version:
 
-* [DANS BagPack Profile v1.0.0](versions/1.0.0.md) (published on 2026-02-10)
+* [DANS BagPack Profile v1.1.0](versions/1.1.0.md) (DRAFT)
+* [DANS BagPack Profile v1.0.0](versions/1.0.0.md) (PUBLISHED)
 
 Archived versions, see [here](versions/archived/index.md). 
 

--- a/docs/versions/1.1.0.md
+++ b/docs/versions/1.1.0.md
@@ -17,7 +17,7 @@ The status of this document is DRAFT.
 
 #### Changed from version 1.0.0 to 1.1.0
 
-Change requiremnt 1.1. to also allow "holey bags" for support of external large objects. This change is backwards compatible, as completely valid bags remain
+Change requirement 1.1. to also allow "holey bags" for support of external large objects. This change is backwards compatible, as completely valid bags remain
 supported as well.
 
 ### Scope

--- a/docs/versions/1.1.0.md
+++ b/docs/versions/1.1.0.md
@@ -73,9 +73,10 @@ The following items are required by the [RDA BagPack]{:target=_blank} specificat
 
 1. One of the following MUST hold:
     * the DANS BagPack is a valid bag, according to [BagIt v1.0]{:target=_blank} or [BagIt v0.97]{:target=_blank}
-    * the DANS BagPack is a holey bag (i.e., a bag with a [fetch.txt]{:target=_blank} file listing the missing files and their fetch URLs), and the files to be
-      fetched are downloadable and have the checksums listed in the payload manifests. In other words: the bag will be valid after all missing files have been
-      fetched.
+    * the DANS BagPack is a holey bag (i.e., a bag with a [fetch.txt]{:target=_blank} file listing the missing files and their fetch URLs). The files to be
+      fetched MUST be downloadable from the given URL or obtainable from a well-known location and have the checksums listed in the payload manifests.
+      "Obtainable from a well-known location" means that the repository containing the bag documents how to map the fetch-URL or a checksum for the file to
+      the location where the file data is stored.
 2. (a) A DANS BagPack MUST contain a file `metadata/datacite.xml` (b) this file MUST be valid according to the
    [DataCite schema version 4.0 or later]{:target=_blank}, except for the requirement that there MUST be a DOI present: a DOI is not required for a DANS
    BagPack; (c) [DataCite's recommended properties]{:target=_blank} SHOULD be present.

--- a/docs/versions/1.1.0.md
+++ b/docs/versions/1.1.0.md
@@ -17,8 +17,8 @@ The status of this document is DRAFT.
 
 #### Changed from version 1.0.0 to 1.1.0
 
-Change requirement 1.1. to also allow "holey bags" for support of external large objects. This change is backwards compatible, as completely valid bags remain
-supported as well.
+Change requirement 1.1. to also allow "holey bags" for support of external large objects. This change is backwards compatible because bags that were valid 
+under the previous versions of this specification remain so.
 
 ### Scope
 

--- a/docs/versions/1.1.0.md
+++ b/docs/versions/1.1.0.md
@@ -6,12 +6,19 @@ Introduction
 
 ### Version
 
-* Document version: 1.0.0
-* Publication date: 2026-02-10
+* Document version: 1.1.0
+* Publication date: n/a
 
 ### Status
 
-The status of this document is PUBLISHED.
+The status of this document is DRAFT.
+
+### Changes
+
+#### Changed from version 1.0.0 to 1.1.0
+
+Change requiremnt 1.1. to also allow "holey bags" for support of external large objects. This change is backwards compatible, as completely valid bags remain
+supported as well.
 
 ### Scope
 
@@ -22,7 +29,7 @@ Vault ingest workflow.
 
 #### Keywords
 
-The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and "OPTIONAL" in this document are to be
+The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
 interpreted as described in [RFC 2119]{:target=_blank}.
 
 The key word "SHOULD" is also used to specify requirements that are impossible or impractical to check by the archival organization (i.e., DANS). The client
@@ -64,7 +71,11 @@ Requirements
 
 The following items are required by the [RDA BagPack]{:target=_blank} specifications:
 
-1. A DANS BagPack MUST be valid according to [BagIt v1.0]{:target=_blank} or [BagIt v0.97]{:target=_blank}.
+1. One of the following MUST hold:
+    * the DANS BagPack is a valid bag, according to [BagIt v1.0]{:target=_blank} or [BagIt v0.97]{:target=_blank}
+    * the DANS BagPack is a holey bag (i.e., a bag with a [fetch.txt]{:target=_blank} file listing the missing files and their fetch URLs), and the files to be
+      fetched are downloadable and have the checksums listed in the payload manifests. In other words: the bag will be valid after all missing files have been
+      fetched.
 2. (a) A DANS BagPack MUST contain a file `metadata/datacite.xml` (b) this file MUST be valid according to the
    [DataCite schema version 4.0 or later]{:target=_blank}, except for the requirement that there MUST be a DOI present: a DOI is not required for a DANS
    BagPack; (c) [DataCite's recommended properties]{:target=_blank} SHOULD be present.
@@ -90,6 +101,7 @@ The following items are required by the DANS BagPack Profile, in addition to the
 
 [RFC 2119]: {{ rfc_2119 }}
 [BagIt v1.0]: {{ bagit }}
+[fetch.txt]: {{ fetch_txt }}
 [BagIt v0.97]: {{ bagit_0_97 }}
 [RDA BagPack]: {{ rda_bagpack }}
 [DataCite schema version 4.0 or later]: {{ datacite_4_0 }}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,7 +25,9 @@ nav:
   - Welcome: index.md
   - Current versions:
     - v1.0.0: versions/1.0.0.md
+    - v1.1.0: versions/1.1.0.md
   - Archived versions:
+    - Overview: versions/archived/index.md
     - v0.1.0: versions/archived/0.1.0.md
   - Context:
     - About: context.md
@@ -33,6 +35,7 @@ nav:
 extra:
   rfc_2119: https://www.ietf.org/rfc/rfc2119.txt
   bagit: https://www.rfc-editor.org/rfc/rfc8493
+  fetch_txt: https://www.rfc-editor.org/rfc/rfc8493#section-2.2.3
   bagit_0_97: https://digitalpreservation.gov/documents/bagitspec.pdf
   rda_bagpack: http://doi.org/10.15497/RDA00025
   datacite_4_0: https://schema.datacite.org/meta/kernel-4.0/


### PR DESCRIPTION
Fixes DD-2234

# Description of changes
Adds version 1.1.0 of DANS BagPack Profile, which relaxes the requirement that the bag must be valid to include holey bags provided that the files referenced in the `fetch.txt` file can be downloaded and have the correct checksum.  

# How to test

```
start-mkdocs.sh
```

# Notify
@DANS-KNAW/core-systems
